### PR TITLE
Validate attestation request shape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -551,9 +551,14 @@ class PrimusZKTLS {
   }
 
   _verifyAttestationParams(attestationParams: SignedAttRequest): boolean {
-    const { attRequest: { appId,
-      attTemplateID,
-      userAddress, timestamp }, appSignature } = attestationParams
+    if (!attestationParams || typeof attestationParams !== 'object') {
+      throw new ZkAttestationError('00005', 'Wrong attestation params!')
+    }
+    const { attRequest, appSignature } = attestationParams
+    if (!attRequest || typeof attRequest !== 'object') {
+      throw new ZkAttestationError('00005', 'Wrong attestation request!')
+    }
+    const { appId, attTemplateID, userAddress, timestamp } = attRequest
     const checkFn = (label: string, value: any, valueType: string) => {
       if (!value) {
         throw new ZkAttestationError('00005', `Missing ${label}!`)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,6 +29,14 @@ describe('listData function', () => {
     expect(encodeData).toBe('0xebb87a4b82fe5980d8e8f43fe98acda9cc44fe98541947004c648a99ff629a3f');
   });
 
+
+  it('rejects malformed attestation params with SDK errors', () => {
+    const zkTLS = new PrimusZKTLS();
+
+    expect(() => (zkTLS as any)._verifyAttestationParams(null)).toThrow('Wrong attestation params!');
+    expect(() => (zkTLS as any)._verifyAttestationParams({ appSignature: '0xsig' })).toThrow('Wrong attestation request!');
+  });
+
   it('verifyAttestation', async () => {
     const att = createAttestation();
     const encodeData = encodeAttestation(att);


### PR DESCRIPTION
`_verifyAttestationParams` currently destructures `attRequest` before checking that the parsed signed request has the expected shape. If callers pass malformed JSON such as `null` or an object without `attRequest`, the SDK throws a raw destructuring `TypeError` instead of its normal `ZkAttestationError` validation path.

This adds explicit shape checks before destructuring, so malformed signed requests fail with SDK validation errors.